### PR TITLE
ci: add IPFS deploy workflow (Storacha) + ENS publish flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,72 @@
+name: Deploy to IPFS
+
+# Publishes the prerendered site to IPFS (via Storacha) once CI passes on main.
+# The CID printed in the job summary goes into the ENS contenthash of
+# cpl121.eth as `ipfs://<CID>`, and eth.limo serves it at cpl121.eth.limo.
+#
+# Requires two repository secrets (generated once with the `storacha` CLI):
+#   STORACHA_PRINCIPAL  -> `storacha key create` (the base64 signing key)
+#   STORACHA_PROOF      -> `storacha delegation create <did> \
+#                            -c space/blob/add -c space/index/add \
+#                            -c filecoin/offer -c upload/add --base64`
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    # Deploy only when CI succeeded on main, or on a manual run.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify build (confidentiality + sitemap)
+        run: npm run verify:build
+
+      - name: Pin to IPFS (Storacha)
+        id: ipfs
+        uses: storacha/add-to-web3@v4
+        with:
+          path_to_add: build
+          secret_key: ${{ secrets.STORACHA_PRINCIPAL }}
+          proof: ${{ secrets.STORACHA_PROOF }}
+
+      - name: Publish CID to job summary
+        run: |
+          CID='${{ steps.ipfs.outputs.cid }}'
+          {
+            echo '## 🛰️ Deployed to IPFS'
+            echo ''
+            echo "**CID:** \`$CID\`"
+            echo ''
+            echo '**Preview via gateway:**'
+            echo "- https://$CID.ipfs.dweb.link/"
+            echo "- ${{ steps.ipfs.outputs.url }}"
+            echo ''
+            echo '### Publish this build'
+            echo 'Set the `contenthash` of **cpl121.eth** to the value below at'
+            echo '<https://app.ens.domains/cpl121.eth> (one signed transaction).'
+            echo 'eth.limo then serves the new build at https://cpl121.eth.limo/'
+            echo ''
+            echo '```'
+            echo "ipfs://$CID"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,35 @@ npm run format    # prettier --write
 
 Requires Node.js ≥ 20. This project uses **npm** as its package manager (`package-lock.json`).
 
+## Deployment
+
+The site is fully prerendered and IPFS-friendly (relative asset paths, `404.html`
+fallback), and is served at [cpl121.eth.limo](https://cpl121.eth.limo) — the
+[eth.limo](https://eth.limo) gateway resolving the `contenthash` of the
+`cpl121.eth` ENS name.
+
+- **CI** (`.github/workflows/ci.yml`) runs the quality gate on every push/PR:
+  audit, lint, type-check, unit tests, build, `verify:build` and E2E smoke tests.
+- **Deploy** (`.github/workflows/deploy.yml`) runs after CI passes on `main`
+  (or manually via _Run workflow_): it builds, verifies, pins `build/` to IPFS
+  with [`storacha/add-to-web3`](https://github.com/storacha/add-to-web3), and
+  prints the resulting **CID** in the job summary.
+- **Publish:** set the `contenthash` of `cpl121.eth` to `ipfs://<CID>` at
+  [app.ens.domains](https://app.ens.domains/cpl121.eth) (one signed transaction).
+  Using an immutable CID — rather than IPNS — means the site never depends on a
+  record being continuously republished.
+
+One-time setup — add two repository secrets generated with the `storacha` CLI:
+
+```bash
+npm i -g @storacha/cli
+storacha login                 # email login, then create/select a space
+storacha key create            # -> STORACHA_PRINCIPAL (the base64 key)
+storacha delegation create <did-from-key-create> \
+  -c space/blob/add -c space/index/add -c filecoin/offer -c upload/add \
+  --base64                     # -> STORACHA_PROOF
+```
+
 ## License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
## Qué

Añade un workflow de despliegue que republica el sitio en IPFS y documenta cómo republicar el ENS, sustituyendo el pipeline IPNS de Fleek (cerrado) que causa el **504 actual** en cpl121.eth.limo.

## Cómo funciona

- `.github/workflows/deploy.yml` corre **tras pasar la CI en `main`** (o manualmente con _Run workflow_): `npm ci` → `build` → `verify:build` → pinea `build/` a IPFS con [`storacha/add-to-web3@v4`](https://github.com/storacha/add-to-web3) → imprime el **CID** en el _job summary_.
- Publicas poniendo el `contenthash` de `cpl121.eth` a `ipfs://<CID>` en [app.ens.domains](https://app.ens.domains/cpl121.eth) (una transacción firmada).
- **CID inmutable** en vez de IPNS: el sitio ya no depende de que un registro IPNS se republique continuamente (la causa de la caída).

## Antes de mergear / usar

Añadir dos secrets del repo (Settings → Secrets → Actions), generados una vez con la CLI de Storacha (pasos en el README):

- `STORACHA_PRINCIPAL` — `storacha key create`
- `STORACHA_PROOF` — `storacha delegation create <did> -c space/blob/add -c space/index/add -c filecoin/offer -c upload/add --base64`

Sin los secrets, el paso de pin fallará; el resto del workflow es inofensivo. Se puede lanzar a mano desde la pestaña Actions una vez configurados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)